### PR TITLE
Adding the FarmOS website link to the word farmOS in the Acknowledgement section of the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ FarmData2 is both a _second_ edition of it predecessor, FarmData, and the integr
 
 ### Acknowledgements ###
 
-FarmData2 is powered by the farmOS open source project.
+FarmData2 is powered by the [farmOS](https://farmos.org/) open source project.
 
 Support and assistance with FarmData2 development has been received from [The Non-Profit FOSS Institute](https://npfi.org/).
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ FarmData2 is both a _second_ edition of it predecessor, FarmData, and the integr
 
 ### Acknowledgements ###
 
-FarmData2 is powered by the [farmOS](https://farmos.org/) open source project. TEST
+FarmData2 is powered by the [farmOS](https://farmos.org/) open source project.
 
 Support and assistance with FarmData2 development has been received from [The Non-Profit FOSS Institute](https://npfi.org/).
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ FarmData2 is both a _second_ edition of it predecessor, FarmData, and the integr
 
 ### Acknowledgements ###
 
-FarmData2 is powered by the [farmOS](https://farmos.org/) open source project.
+FarmData2 is powered by the [farmOS](https://farmos.org/) open source project. TEST
 
 Support and assistance with FarmData2 development has been received from [The Non-Profit FOSS Institute](https://npfi.org/).
 


### PR DESCRIPTION
__Pull Request Description__
Fixes #39 

Add The farmOS website link to the word farmOS in the bottom section of the readme file, where the acknowledgement section is

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
